### PR TITLE
Pin activesupport to ~> 7.0.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,3 +26,8 @@ end
 # jekyll 4.2.2) calls String#tainted?, which Ruby 3.2 removed. Lifting
 # this pin requires upgrading jekyll/liquid as well.
 gem 'nokogiri', '~> 1.16.5'
+
+# Pinned: activesupport >= 7.2 requires Ruby >= 3.1. Pulled in transitively
+# by html-pipeline (>= 2) via jemoji, so dependabot will otherwise propose
+# breaking bumps. Lift together with the nokogiri pin.
+gem 'activesupport', '~> 7.0.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activesupport (~> 7.0.7)
   feedjira
   httparty
   jekyll


### PR DESCRIPTION
activesupport >= 7.2 requires Ruby >= 3.1, but the deploy is on Ruby 3.0.2 (constrained by liquid 4.0.3 / jekyll 4.2.2). It enters the bundle transitively via html-pipeline (which accepts >= 2), so dependabot keeps proposing breaking bumps. Lift this together with the nokogiri pin once jekyll/liquid are upgraded.