### PR TITLE
Pin httparty to ~> 0.21.0 and multi_xml to ~> 0.6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :jekyll_plugins do
     gem 'webrick'
 end
 group :other_plugins do
-    gem 'httparty'
+    gem 'httparty', '~> 0.21.0'
     gem 'feedjira'
 end
 
@@ -31,3 +31,8 @@ gem 'nokogiri', '~> 1.16.5'
 # by html-pipeline (>= 2) via jemoji, so dependabot will otherwise propose
 # breaking bumps. Lift together with the nokogiri pin.
 gem 'activesupport', '~> 7.0.7'
+
+# Pinned: multi_xml >= 0.8 requires Ruby >= 3.2. Pulled in transitively
+# by httparty (>= 0.5.2), so it can cascade independently of the httparty
+# pin above. Lift together with the nokogiri pin.
+gem 'multi_xml', '~> 0.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (~> 7.0.7)
   feedjira
-  httparty
+  httparty (~> 0.21.0)
   jekyll
   jekyll-archives
   jekyll-diagrams
@@ -165,6 +165,7 @@ DEPENDENCIES
   jekyll-twitter-plugin
   jemoji
   mini_racer
+  multi_xml (~> 0.6.0)
   nokogiri (~> 1.16.5)
   unicode_utils
   webrick


### PR DESCRIPTION
httparty 0.24 cascades multi_xml >= 0.8, which requires Ruby >= 3.2 — the deploy is on Ruby 3.0.2 (constrained by liquid/jekyll). Pinning httparty alone isn't enough since multi_xml is a transitive dep with a loose constraint, so it can bump independently. Lift both with the nokogiri pin once jekyll/liquid are upgraded.