### PR TITLE
Pin public_suffix to ~> 4.0.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,3 +36,8 @@ gem 'activesupport', '~> 7.0.7'
 # by httparty (>= 0.5.2), so it can cascade independently of the httparty
 # pin above. Lift together with the nokogiri pin.
 gem 'multi_xml', '~> 0.6.0'
+
+# Pinned: public_suffix >= 7 requires Ruby >= 3.2. Pulled in transitively
+# by addressable, so dependabot will otherwise propose breaking bumps.
+# Lift together with the nokogiri pin.
+gem 'public_suffix', '~> 4.0.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,7 @@ DEPENDENCIES
   mini_racer
   multi_xml (~> 0.6.0)
   nokogiri (~> 1.16.5)
+  public_suffix (~> 4.0.7)
   unicode_utils
   webrick
 


### PR DESCRIPTION
public_suffix >= 7 requires Ruby >= 3.2. Pulled in transitively by addressable, so dependabot will otherwise propose breaking bumps. Lift together with the nokogiri pin once jekyll/liquid are upgraded.