### PR TITLE
Bump addressable to 2.9.0 (GHSA-h27x-rffw-24p4)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,3 +41,7 @@ gem 'multi_xml', '~> 0.6.0'
 # by addressable, so dependabot will otherwise propose breaking bumps.
 # Lift together with the nokogiri pin.
 gem 'public_suffix', '~> 4.0.7'
+
+# Bumped to 2.9.0 to fix GHSA-h27x-rffw-24p4 (ReDoS in Addressable
+# templates). public_suffix pin above caps the cascade at 4.x.
+gem 'addressable', '~> 2.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     bibtex-ruby (6.0.0)
       latex-decode (~> 0.0)
     citeproc (1.0.10)
@@ -149,6 +149,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 7.0.7)
+  addressable (~> 2.9.0)
   feedjira
   httparty (~> 0.21.0)
   jekyll


### PR DESCRIPTION
Fixes High-severity ReDoS in Addressable templates (CVE-2023-30605). Adds an explicit Gemfile pin so dependabot doesn't bump past 2.9.x without us reviewing. The existing public_suffix '~> 4.0.7' pin caps the transitive cascade at 4.x, since 2.9.0 widens its constraint to public_suffix < 8.0.