### PR TITLE
Bump httparty to 0.24.0 (GHSA-hm5p-x4rq-38w4)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :jekyll_plugins do
     gem 'webrick'
 end
 group :other_plugins do
-    gem 'httparty', '~> 0.21.0'
+    gem 'httparty', '~> 0.24.0'
     gem 'feedjira'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
     csl-styles (1.0.1.11)
       csl (~> 1.0)
     cssminify2 (2.0.1)
+    csv (3.3.5)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -40,7 +41,8 @@ GEM
       nokogiri (>= 1.4)
     htmlcompressor (0.4.0)
     http_parser.rb (0.8.0)
-    httparty (0.21.0)
+    httparty (0.24.0)
+      csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     i18n (1.14.1)
@@ -150,7 +152,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (~> 7.0.7)
   feedjira
-  httparty (~> 0.21.0)
+  httparty (~> 0.24.0)
   jekyll
   jekyll-archives
   jekyll-diagrams


### PR DESCRIPTION
Fixes High-severity SSRF that can leak API keys (CVE-2025-68696). 0.24.0 adds csv as a runtime dep — added to the lock at 3.3.5. multi_xml '~> 0.6.0' pin caps the cascade at 0.6.x (httparty 0.24.0 only requires multi_xml >= 0.5.2, so the pin is satisfied without pulling in 0.8.x which needs Ruby 3.2).